### PR TITLE
Update mac directions to not require a root user

### DIFF
--- a/doc/MacReadme.txt
+++ b/doc/MacReadme.txt
@@ -5,10 +5,10 @@ To install on Mac OS X with the .zip distribution (first seen in 1.3.6) you must
 
   1. Extract the zip file to any location (usually double click will do this)
   2. Open Terminal, and cd to the extracted directory (e.g. /Users/my-name/Downloads/extracted-dir/)
-  3. Change to super user (use the su command)
-  4. Copy the binaries to /usr/bin using: cp synergy* /usr/bin
+  3. Copy the binaries to /usr/bin using: sudo cp synergy* /usr/bin
+  4. Correct the permissions and ownership: sudo chown root:wheel /usr/bin/synergy*; sudo chmod 555 /usr/bin/synergy*
 
-How to enable the root user in Mac OS X:
+Alternatively, you can copy the binaries as root. How to enable the root user in Mac OS X:
   http://support.apple.com/en-us/ht1528
 
 Once the binaries have been copied to /usr/bin, you should follow the configuration guide:


### PR DESCRIPTION
I updated the directions such that a clear installation path is provided that does not require the direct use of root.